### PR TITLE
fix: navigate to previous page after login on product CTAs

### DIFF
--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { IsItemInCart } from "../utils/isItemInCart";
 import { IsItemInWishList } from "../utils/isItemInWishList";
 import { useAuth } from "../context/auth-context";
@@ -30,6 +30,7 @@ export const ProductCard = ({ cardDetails }) => {
   const inWishList = IsItemInWishList(_id);
   const inCart = IsItemInCart(_id);
   const navigate = useNavigate();
+  const { pathname } = useLocation();
 
   return (
     <>
@@ -65,7 +66,11 @@ export const ProductCard = ({ cardDetails }) => {
                     itemDetails: cardDetails,
                     dispatchWishList,
                   })
-                : navigate("/login");
+                : navigate(
+                    "/login",
+                    { state: { from: { pathname: pathname } } },
+                    { replace: true }
+                  );
             }}
           >
             favorite_border
@@ -104,7 +109,11 @@ export const ProductCard = ({ cardDetails }) => {
                     itemDetails: { ...cardDetails, quantity: 1 },
                     dispatchCart,
                   })
-                : navigate("/login");
+                : navigate(
+                    "/login",
+                    { state: { from: { pathname: pathname } } },
+                    { replace: true }
+                  );
             }}
           >
             <i className="material-icons">shopping_cart</i>

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -17,7 +17,7 @@ export const Login = () => {
   const editLoginForm = useRef(null);
   const navigate = useNavigate();
   const location = useLocation();
-  const from = location.state?.from?.pathname || "/products";
+  const from = location.state?.from?.pathname || "/";
 
   const handleLoginForm = (e) => {
     e.preventDefault();
@@ -39,7 +39,7 @@ export const Login = () => {
         token: response.data.encodedToken,
         isLoggedIn: true,
       });
-      
+
       const prevCartData = response.data.foundUser.cart;
       const prevWishlistData = response.data.foundUser.wishlist;
 
@@ -48,6 +48,7 @@ export const Login = () => {
 
       setTestData({ email: "", password: "" });
       toast.success("Login Success");
+
       navigate(from, { replace: true });
     } catch (error) {
       console.log("Login Error", error);

--- a/src/pages/SingleProductPage.jsx
+++ b/src/pages/SingleProductPage.jsx
@@ -1,7 +1,7 @@
 import { Navbar } from "../components/Navbar";
 import { Footer } from "../components/Footer";
 import "../styles/pages/singleProductPage.css";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useNavigate, Link, useLocation } from "react-router-dom";
 import { Loader } from "../components/Loader";
 import { GetProductById } from "../services/getProductById";
 import { IsItemInCart } from "../utils/isItemInCart";
@@ -25,6 +25,7 @@ export const SingleProductPage = () => {
   const { dispatchCart } = useCart();
   const inWishList = IsItemInWishList(productId);
   const inCart = IsItemInCart(productId);
+  const { pathname } = useLocation();
   const {
     _id,
     title,
@@ -78,7 +79,11 @@ export const SingleProductPage = () => {
                             itemDetails: { ...product, quantity: 1 },
                             dispatchCart,
                           })
-                        : navigate("/login");
+                        : navigate(
+                            "/login",
+                            { state: { from: { pathname: pathname } } },
+                            { replace: true }
+                          );
                     }}
                   >
                     <i className="material-icons">shopping_cart</i>
@@ -109,7 +114,11 @@ export const SingleProductPage = () => {
                             itemDetails: product,
                             dispatchWishList,
                           })
-                        : navigate("/login");
+                        : navigate(
+                            "/login",
+                            { state: { from: { pathname: pathname } } },
+                            { replace: true }
+                          );
                     }}
                   >
                     <i className="material-icons red-color">favorite_border</i>


### PR DESCRIPTION
fix: navigate to the previous page after login on product CTAs

Initially after clicking add to cart, add to wishlist buttons, it was navigating to the login page without storing the page path.
Now I am storing the path inside the location variable of useLocation of react-router-dom.
So now it will store the pathname in location, and after login success, it will be able to access the previous path which we have stored from the location for redirecting to that page.

